### PR TITLE
Update Chromium patch (66.0.3359.117)

### DIFF
--- a/chrome/https-by-default.patch
+++ b/chrome/https-by-default.patch
@@ -1,25 +1,25 @@
 diff --git a/components/toolbar/toolbar_model_impl.cc b/components/toolbar/toolbar_model_impl.cc
-index 0cefbc6b..2865d67 100644
+index 2d23c24defe2..3795ce4194d9 100644
 --- a/components/toolbar/toolbar_model_impl.cc
 +++ b/components/toolbar/toolbar_model_impl.cc
-@@ -54,7 +54,8 @@ base::string16 ToolbarModelImpl::GetFormattedURL(size_t* prefix_end) const {
+@@ -48,7 +48,8 @@ base::string16 ToolbarModelImpl::GetFormattedFullURL() const {
    const base::string16 formatted_text =
        delegate_->FormattedStringWithEquivalentMeaning(
            url, url_formatter::FormatUrl(
 -                   url, url_formatter::kFormatUrlOmitDefaults,
 +                   url, (url_formatter::kFormatUrlOmitDefaults &
 +                         ~url_formatter::kFormatUrlOmitHTTP),
-                    net::UnescapeRule::NORMAL, nullptr, prefix_end, nullptr));
-   if (formatted_text.length() <= max_url_display_chars_)
-     return formatted_text;
+                    net::UnescapeRule::NORMAL, nullptr, nullptr, nullptr));
+ 
+   // Truncating the URL breaks editing and then pressing enter, but hopefully
 diff --git a/components/omnibox/browser/autocomplete_input.cc b/components/omnibox/browser/autocomplete_input.cc
-index d5e10f5b..fc590a1 100644
+index 43fc0dc783d8..1f7e5ce9dee1 100644
 --- a/components/omnibox/browser/autocomplete_input.cc
 +++ b/components/omnibox/browser/autocomplete_input.cc
-@@ -288,6 +288,18 @@ metrics::OmniboxInputType::Type AutocompleteInput::Parse(
+@@ -285,6 +285,18 @@ metrics::OmniboxInputType AutocompleteInput::Parse(
    // between an HTTP URL and a query, or the scheme is HTTP or HTTPS, in which
    // case we should reject invalid formulations.
-
+ 
 +  if (!parts->scheme.is_nonempty() &&
 +      base::LowerCaseEqualsASCII(parsed_scheme_utf8, url::kHttpScheme)) {
 +    // Scheme was not specified. url_fixer::FixupURL automatically adds http:,


### PR DESCRIPTION
Old patch did not apply (probably due to commit 142de38acea69).
Fixed by changing one line in the patch
```net::UnescapeRule::NORMAL, nullptr, prefix_end, nullptr));```
into
```net::UnescapeRule::NORMAL, nullptr, nullptr, nullptr));```

Updated patch is generated by executing `git diff 66.0.3359.117` in the chromium source repo.